### PR TITLE
Bug 1508974: Update github pages site home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # GeckoView
 
-This repository contains examples for [GeckoView](https://wiki.mozilla.org/Mobile/GeckoView).
+## Tutorials
+
+* [GeckoView Contributor Quick Start Guide](tutorials/geckoview-quick-start.md)
+* [Mozilla Central Quick Start Guide](tutorials/mc-quick-start.md)
+* [Mozilla Central Contributor Guide](tutorials/contributing-to-mc.md)
+* [Guide to Native Debugging in Android Studio](tutorials/native-debugging.md)
+
+## API Documentation
+
+* [Changelog](javadoc/mozilla-central/org/mozilla/geckoview/doc-files/CHANGELOG.md)
+* [API](javadoc/mozilla-central/index.html)
+
+## More information
+You can read more about GeckoView on the [wiki](https://wiki.mozilla.org/Mobile/GeckoView).

--- a/tutorials/contributing-to-mc.md
+++ b/tutorials/contributing-to-mc.md
@@ -1,7 +1,7 @@
 
 # Submitting a patch to Firefox using Git.
 
-This guide will take you through submitting and updating a patch to `mozilla-central` as a git user. You need to already be [set up to use git to contribute to `mozilla-central`](MozCentralQuickStart.md).
+This guide will take you through submitting and updating a patch to `mozilla-central` as a git user. You need to already be [set up to use git to contribute to `mozilla-central`](mc-quick-start.md).
 
 ## Performing a bug fix
 

--- a/tutorials/geckoview-quick-start.md
+++ b/tutorials/geckoview-quick-start.md
@@ -7,7 +7,7 @@ You may also be interested in how to get up and running with [Firefox For Androi
 
 ## Get set up with Mozilla Central
 
-The GeckoView codebase is part of the main Firefox tree and can be found in `mozilla-central`. You will need to get set up as a contributor to Firefox in order to contribute to GeckoView. To get set up with `mozilla-central`, follow the [Quick Start Guide for Git Users](MozCentralQuickStart.md), or the [Contributing to the Mozilla code base](https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction) guide on [MDN](https://developer.mozilla.org/) for Mercurial users.
+The GeckoView codebase is part of the main Firefox tree and can be found in `mozilla-central`. You will need to get set up as a contributor to Firefox in order to contribute to GeckoView. To get set up with `mozilla-central`, follow the [Quick Start Guide for Git Users](mc-quick-start.md), or the [Contributing to the Mozilla code base](https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction) guide on [MDN](https://developer.mozilla.org/) for Mercurial users.
 
 Once you have a copy of `mozilla-central`, you will need to build GeckoView.
 
@@ -80,7 +80,7 @@ Now you're set up and ready to go.
 
 ## Performing a bug fix
 
-One you have got GeckoView building and running, you will want to start contributing. There is a general guide to [Performing a Bug Fix for Git Developers](ContributingToMC.md) for you to follow. To contribute to GeckoView specifically, you will need the following additional information.
+One you have got GeckoView building and running, you will want to start contributing. There is a general guide to [Performing a Bug Fix for Git Developers](contributing-to-mc.md) for you to follow. To contribute to GeckoView specifically, you will need the following additional information.
 
 It is advisable to run your tests before submitting your patch. You can do this using Mozilla's `try` server. To submit a GeckoView patch to `try` before submitting it for review, type:
 ```
@@ -173,4 +173,4 @@ dependencies {
 
 ## Next Steps
 
-- Get started with [Native Debugging](NativeDebugging.md)
+- Get started with [Native Debugging](native-debugging.md)

--- a/tutorials/mc-quick-start.md
+++ b/tutorials/mc-quick-start.md
@@ -113,4 +113,4 @@ git config remote.try.push +HEAD:refs/heads/branches/default/tip
 git remote update
 ```
 
-All that's left to do now is pick a bug to fix and [submit a patch](ContributingToMC.md).
+All that's left to do now is pick a bug to fix and [submit a patch](contributing-to-mc.md).

--- a/tutorials/native-debugging.md
+++ b/tutorials/native-debugging.md
@@ -1,7 +1,7 @@
 # Debugging Native Code in Android Studio.
 If you want to work on the C++ code that powers GeckoView, you will need to be able to perform native debugging inside Android Studio. This article will guide you through how to do that. 
 
-If you need to get set up with GeckoView for the first time, follow the [Quick Start Guide](GeckoViewQuickStart.md).
+If you need to get set up with GeckoView for the first time, follow the [Quick Start Guide](geckoview-quick-start.md).
 
 ## Perform a debug build of Gecko.
 1. Edit your `mozconfig` file and add the following lines. These will ensure that the build is performed generating debug symbols.


### PR DESCRIPTION
Ensure it links to Javadoc, tutorials and Wiki to make the landing page more usable.