### PR TITLE
Include some missing information and prioritise consumer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 # GeckoView
 
-## Tutorials
+## Get Started with GeckoView
+
+* [GeckoView Quick Start Guide](https://wiki.mozilla.org/Mobile/GeckoView#Get_Started)
+
+
+## API Documentation
+
+* [Changelog](javadoc/mozilla-central/org/mozilla/geckoview/doc-files/CHANGELOG.md)
+* [API](javadoc/mozilla-central/index.html)
+
+## Get Started as a Contributor
 
 * [GeckoView Contributor Quick Start Guide](tutorials/geckoview-quick-start.md)
 * [Mozilla Central Quick Start Guide](tutorials/mc-quick-start.md)
 * [Mozilla Central Contributor Guide](tutorials/contributing-to-mc.md)
 * [Guide to Native Debugging in Android Studio](tutorials/native-debugging.md)
 
-## API Documentation
-
-* [Changelog](javadoc/mozilla-central/org/mozilla/geckoview/doc-files/CHANGELOG.md)
-* [API](javadoc/mozilla-central/index.html)
 
 ## More information
 You can read more about GeckoView on the [wiki](https://wiki.mozilla.org/Mobile/GeckoView).

--- a/tutorials/contributing-to-mc.md
+++ b/tutorials/contributing-to-mc.md
@@ -15,7 +15,7 @@ git remote update
 ```
 * Create a new feature branch tracking either Central or Inbound.
 
-```
+```bash
 git checkout -b bugxxxxxxx [inbound|central]/default
 ```
 * Work on your bug, checking into git according to your preferred workflow. _Try to ensure that each individual commit compiles and passes all of the tests for your component. This will make it easier to land if you use `moz-phab` to submit (details later in this post)._
@@ -29,6 +29,14 @@ Level 3: Core access. You will need this level to commit to any of the core repo
 If you wish to apply for commit access, please follow the guide found in the [Mozilla Commit Access Policy](https://www.mozilla.org/en-US/about/governance/policies/commit/access-policy/).
 
 If you do not have access and still want to submit your fix, you can create a patch and attach it directly to the Bugzilla ticket. We do not recommend this method, though, and strongly encourage contributors to apply for commit access.
+
+### Submitting a patch that touches C/C++
+
+If your patch makes changes to any C or C++ code and your editor does not have `clang-format` support, you should run the clang-format linter before submitting your patch to ensure that your code is properly formatted.
+
+```bash
+mach clang-format -p path/to/file.cpp
+```
 
 ### Attaching a patch in Bugzilla
 

--- a/tutorials/geckoview-quick-start.md
+++ b/tutorials/geckoview-quick-start.md
@@ -90,22 +90,14 @@ If the patch that you want to submit changes the public API for GeckoView, you m
 ./mach android api-lint
 ```
 
-The output of this command will inform you if any changes you have made break the existing API. Review the changes and, if they are correct, update your api.txt to conform to your changed by running:
+The output of this command will inform you if any changes you have made break the existing API. Review the changes and follow the instructions it provides.
 
-```bash
-./gradlew apiUpdateFileWithGeckoBinariesDebug
-```
-
-After updating the API documentation, rerun `mach android api-lint`. This will then provide you with a changelog hash number. Open `mobile/android/geckoview/src/main/java/org/mozilla/geckoview/doc-files/CHANGELOG.md` and make the following changes.
-
-1. Under the heading for the next release version, add a new entry for the changes that you are making to the API, along with links to any relevant files. i.e.
+If the linter asks you to update the changelog, please ensure that you follow the correct format for changelog entries. Under the heading for the next release version, add a new entry for the changes that you are making to the API, along with links to any relevant files. i.e.
 
   ```
   - Added methods for each setting in [`GeckoSessionSettings`][66.3] 
   [66.3]: ../GeckoSessionSettings.html
   ```
-
-2. Copy and paste the changelog hash from the api-lint output against the `[api-version]` entry at the bottom of the file.
 
 ### Submitting to the `try` server
 

--- a/tutorials/geckoview-quick-start.md
+++ b/tutorials/geckoview-quick-start.md
@@ -82,12 +82,41 @@ Now you're set up and ready to go.
 
 One you have got GeckoView building and running, you will want to start contributing. There is a general guide to [Performing a Bug Fix for Git Developers](contributing-to-mc.md) for you to follow. To contribute to GeckoView specifically, you will need the following additional information.
 
-It is advisable to run your tests before submitting your patch. You can do this using Mozilla's `try` server. To submit a GeckoView patch to `try` before submitting it for review, type:
+### Updating the changelog and API documentation
+
+If the patch that you want to submit changes the public API for GeckoView, you must ensure that the API documentation is kept up to date. To check whether your patch has altered the API, run the following command.
+
+```bash
+./mach android api-lint
 ```
+
+The output of this command will inform you if any changes you have made break the existing API. Review the changes and, if they are correct, update your api.txt to conform to your changed by running:
+
+```bash
+./gradlew apiUpdateFileWithGeckoBinariesDebug
+```
+
+After updating the API documentation, rerun `mach android api-lint`. This will then provide you with a changelog hash number. Open `mobile/android/geckoview/src/main/java/org/mozilla/geckoview/doc-files/CHANGELOG.md` and make the following changes.
+
+1. Under the heading for the next release version, add a new entry for the changes that you are making to the API, along with links to any relevant files. i.e.
+
+  ```
+  - Added methods for each setting in [`GeckoSessionSettings`][66.3] 
+  [66.3]: ../GeckoSessionSettings.html
+  ```
+
+2. Copy and paste the changelog hash from the api-lint output against the `[api-version]` entry at the bottom of the file.
+
+### Submitting to the `try` server
+
+It is advisable to run your tests before submitting your patch. You can do this using Mozilla's `try` server. To submit a GeckoView patch to `try` before submitting it for review, type:
+```bash
 ./mach try fuzzy -q "android"
 ```
 
 This will run all of the Android test suite. If your patch passes on `try` you can be (fairly) confident that it will land successfully after review.
+
+### Tagging a reviewer
 
 When submitting a patch to Phabricator, if you know who you want to review your patch, put their Phabricator handle against the `reviewers` field. 
 
@@ -100,7 +129,7 @@ If you don't know who to tag for a review in the Phabricator submission message,
 
 If you want to include a development version of GeckoView as a dependency inside another app, you must link to a local copy. There are two ways of doing this, publishing GeckoView to a local Maven repository (recommended), or linking to a local archive/
 
-### Public to a local repository
+### Publish to a local repository
 
 Publish GeckoView to your local maven by running
 


### PR DESCRIPTION
Just some very small tweaks.

1. We were prioritising contributor docs over consumer docs and that's probably incorrect so I tweaked that.
2. We did not include any linting/api/changelog information in our quick start guide so I added some.
3. I did not mention clang-format anywhere in the c/c++ bug submission information and that bit me, so I've added that too.