### PR TITLE
Fixes #35: Use baseurl in _config.yml to fix CHANGELOG links.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@ title: GeckoView
 email: etoop@mozilla.com
 description:
   The privacy focussed WebView you've been looking for.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://mozilla.github.io/geckoview" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/geckoview" # the subpath of your site, e.g. /blog
+url: "https://mozilla.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: geckoview
 github_username:  mozilla
 tags: [GeckoView,Gecko,mozilla,android,WebView,web,browser,toolkit,open source,privacy,online,security,mobile]

--- a/_includes/javadoc.html
+++ b/_includes/javadoc.html
@@ -1,7 +1,7 @@
 
     <li class="navigation-list-item{% if page.url contains '/javadoc/' %} active{% endif %}">
-        <a href="{{ site.url }}/javadoc/mozilla-central/index.html" class="navigation-list-link{% if page.url contains '/javadoc/' %} active{% endif %}">API Documentation</a>
+        <a href="{{ site.url }}{{ site.baseurl }}/javadoc/mozilla-central/index.html" class="navigation-list-link{% if page.url contains '/javadoc/' %} active{% endif %}">API Documentation</a>
     </li>
     <li class="navigation-list-item{% if page.url contains 'CHANGELOG' %} active{% endif %}">
-        <a href="{{ site.url }}/javadoc/mozilla-central/org/mozilla/geckoview/doc-files/CHANGELOG" class="navigation-list-link{% if page.url contains 'CHANGELOG' %} active{% endif %}">API Changelog</a>
+        <a href="{{ site.url }}{{ site.baseurl }}/javadoc/mozilla-central/org/mozilla/geckoview/doc-files/CHANGELOG" class="navigation-list-link{% if page.url contains 'CHANGELOG' %} active{% endif %}">API Changelog</a>
     </li>


### PR DESCRIPTION
Without this change jekyll thinks that the base for all URLs is "/" so it would
transform relative links in the `CHANGELOG` file to the wrong path.

See also: https://stackoverflow.com/a/19173888/1020817