### PR TITLE
Fixes #37: Only highlight API Changelog when selected.

### DIFF
--- a/_includes/javadoc.html
+++ b/_includes/javadoc.html
@@ -1,6 +1,6 @@
 
-    <li class="navigation-list-item{% if page.url contains '/javadoc/' %} active{% endif %}">
-        <a href="{{ site.url }}{{ site.baseurl }}/javadoc/mozilla-central/index.html" class="navigation-list-link{% if page.url contains '/javadoc/' %} active{% endif %}">API Documentation</a>
+    <li class="navigation-list-item{% if page.url contains '/javadoc/mozilla-central/index.html' %} active{% endif %}">
+        <a href="{{ site.url }}{{ site.baseurl }}/javadoc/mozilla-central/index.html" class="navigation-list-link{% if page.url contains '/javadoc/mozilla-central/index.html' %} active{% endif %}">API Documentation</a>
     </li>
     <li class="navigation-list-item{% if page.url contains 'CHANGELOG' %} active{% endif %}">
         <a href="{{ site.url }}{{ site.baseurl }}/javadoc/mozilla-central/org/mozilla/geckoview/doc-files/CHANGELOG" class="navigation-list-link{% if page.url contains 'CHANGELOG' %} active{% endif %}">API Changelog</a>


### PR DESCRIPTION
Before this commit both API Changelog and API Documentation were selected
because `/javadoc` matches the `CHANGELOG` path too.