### PR TITLE
Include mozbuild's clang in suggested mozconfig

### DIFF
--- a/tutorials/geckoview-quick-start.md
+++ b/tutorials/geckoview-quick-start.md
@@ -54,7 +54,11 @@ ac_add_options --with-java-bin-path="/Library/Java/Home/bin"
 ac_add_options --with-android-sdk="$HOME/.mozbuild/<your-sdk>"
 ac_add_options --with-android-ndk="$HOME/.mozbuild/android-ndk-r17b"
 
+# With the following compiler toolchain:
+CC="~/.mozbuild/clang/bin/clang"
+CXX="~/.mozbuild/clang/bin/clang++"
 ```
+
 * Configure your build.
 
 ```bash


### PR DESCRIPTION
Ehsan ran into this when he set up his local GeckoView build.
The suggested mozconfig uses the system's compiler, which may not be able to build the NDK.
The clang installed into the mozbuild directory is able to build it.

The following message apparently didn't print for Ehsan during the mach bootstrap process:
https://searchfox.org/mozilla-central/rev/7abb9117c8500ed20833746c9f8e800fce3a4688/python/mozboot/mozboot/android.py#65-68