### PR TITLE
Fix path to root Gradle project.

### DIFF
--- a/tutorials/geckoview-quick-start.md
+++ b/tutorials/geckoview-quick-start.md
@@ -78,7 +78,7 @@ In order to pick up the configuration changes we just made we need to build from
   
   ![alt text]({{ site.url }}/assets/DisableInstantRun.png "Disable Instant Run")
 * Choose File->Open from the toolbar
-* Navigate to <path to gecko>/mobile/android/geckoview and click "Open"
+* Navigate to the root of your `mozilla-central` source directory and click "Open"
 * Click yes if it asks if you want to use the gradle wrapper.
 * Wait for the project to index and gradle to sync. Once synced, the workspace will reconfigure to display the different projects.
   * annotations contains custom annotations used inside GeckoView and Fennec.


### PR DESCRIPTION
Credit to :sefeng for highlighting the incorrect path in #mobile on IRC.  It's tricky because it kinda-sorta works to open `mobile/android/geckoview`, in that there does exist a project that can be opened -- it's just not a useful project to open.