### PR TITLE
Add CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+geckoview.dev


### PR DESCRIPTION
geckoview.dev seems to be setup to redirect, but didn't have [a CNAME file](https://help.github.com/en/articles/setting-up-a-custom-subdomain) so that the custom domain shows up in the url bar and not the github one.

See also: https://github.com/mozilla-mobile/android-components/blob/master/docs/CNAME