### PR TITLE
Update GV quick start guide with ESLint

### DIFF
--- a/contributor/geckoview-quick-start.md
+++ b/contributor/geckoview-quick-start.md
@@ -79,7 +79,7 @@ Now you're set up and ready to go.
 
 One you have got GeckoView building and running, you will want to start contributing. There is a general guide to [Performing a Bug Fix for Git Developers](contributing-to-mc) for you to follow. To contribute to GeckoView specifically, you will need the following additional information.
 
-### Running tests locally
+### Running tests and linter locally
 
 To ensure that your patch does not break existing functionality in GeckoView, you can run the junit test suite with the following command
 
@@ -92,6 +92,12 @@ This command also allows you to run individual tests or test classes, e.g.
 ```
 ./mach geckoview-junit org.mozilla.geckoview.test.NavigationDelegateTest
 ./mach geckoview-junit org.mozilla.geckoview.test.NavigationDelegateTest#loadUnknownHost
+```
+
+If your patch makes a GeckoView JavaScript module, you should run ESLint as well:
+
+```
+./mach lint -l eslint mobile/android/modules/geckoview/
 ```
 
 ### Updating the changelog and API documentation


### PR DESCRIPTION
Add instructions for running ESLint as well if JavaScript changes are also made.

This was not obvious to me at least until my changes were backed out from the linter failing.